### PR TITLE
Removing of uncatch test uncertainty

### DIFF
--- a/test/__snapshots__/server.test.js.snap
+++ b/test/__snapshots__/server.test.js.snap
@@ -81,9 +81,9 @@ exports[`shows uncatch rejects 1`] = `
 " ERROR  Test Error at 1970-01-01 00:00:00
         fake stacktrace
 
-Error event: Test Error
  INFO   Shutting down Logux server at 1970-01-01 00:00:00
 
+Error event: Test Error
 "
 `;
 

--- a/test/servers/uncatch.js
+++ b/test/servers/uncatch.js
@@ -10,7 +10,19 @@ const app = new Server({
   supports: '1.x'
 })
 
-app.on('error', e => console.log(`Error event: ${ e.message }`))
+const errorPromise = new Promise(resolve => {
+  app.on('error', e => {
+    // Waiting for server destruction message
+    setTimeout(() => {
+      console.log(`Error event: ${ e.message }`)
+      resolve()
+    }, 50)
+  })
+})
+
+app.unbind.push(() => new Promise(resolve => {
+  errorPromise.then(resolve)
+}))
 
 new Promise((resolve, reject) => {
   setTimeout(() => {


### PR DESCRIPTION
Issue #26 

I made research and this solution works. There are two main things:
1. We are making timeout for destruction start message come first.
2. We are stoping server from total destruction until error message shows up.