### PR TITLE
Move part of reporter API to logger

### DIFF
--- a/create-reporter/index.js
+++ b/create-reporter/index.js
@@ -197,12 +197,12 @@ const REPORTERS = {
 
 function createReporter (options) {
   let logger
-  if (options.logger) {
+  if (typeof options.logger === 'object') {
     logger = options.logger
   } else {
     let stream = options.reporterStream || pino.destination()
     let prettifier = {}
-    if (options.reporter === 'human') {
+    if (options.logger === 'human') {
       let env = options.env || process.env.NODE_ENV || 'development'
       let color = env !== 'development' ? false : undefined
       prettifier = {

--- a/create-reporter/index.js
+++ b/create-reporter/index.js
@@ -195,40 +195,38 @@ const REPORTERS = {
   }
 }
 
-function createReporter (options) {
-  let logger
-  if (typeof options.logger === 'object') {
-    logger = options.logger
-  } else {
-    let stream = options.reporterStream || pino.destination()
-    let prettifier = {}
-    if (options.logger === 'human') {
-      let env = options.env || process.env.NODE_ENV || 'development'
-      let color = env !== 'development' ? false : undefined
-      prettifier = {
-        prettyPrint: {
-          basepath: options.root,
-          color
-        },
-        prettifier: humanFormatter
-      }
-    }
-    logger = pino(
-      {
-        name: 'logux-server',
-        timestamp: pino.stdTimeFunctions.isoTime,
-        ...prettifier
+function createLogger (options) {
+  let stream = options.reporterStream || pino.destination()
+  let prettifier = {}
+  if (options.logger === 'human') {
+    let env = options.env || process.env.NODE_ENV || 'development'
+    let color = env !== 'development' ? false : undefined
+    prettifier = {
+      prettyPrint: {
+        basepath: options.root,
+        color
       },
-      stream
-    )
+      prettifier: humanFormatter
+    }
   }
+  return pino(
+    {
+      name: 'logux-server',
+      timestamp: pino.stdTimeFunctions.isoTime,
+      ...prettifier
+    },
+    stream
+  )
+}
 
+function createReporter (options) {
   function reporter (type, details) {
     let report = REPORTERS[type](details)
     let level = report.level || 'info'
     reporter.logger[level](report.details || details || {}, report.msg)
   }
-  reporter.logger = logger
+  reporter.logger =
+    typeof options.logger === 'object' ? options.logger : createLogger(options)
   return reporter
 }
 

--- a/create-reporter/index.test.ts
+++ b/create-reporter/index.test.ts
@@ -104,7 +104,7 @@ it('creates human reporter', () => {
   let reporterStream = new MemoryStream()
   let reporter = createReporter({
     reporterStream,
-    reporter: 'human',
+    logger: 'human',
     root: '/dir/'
   })
   reporter('unknownType', {})
@@ -112,24 +112,24 @@ it('creates human reporter', () => {
 })
 
 it('adds trailing slash to path', () => {
-  let reporter = createReporter({ reporter: 'human', root: '/dir' })
+  let reporter = createReporter({ logger: 'human', root: '/dir' })
   expect(reporter.logger.basepath).toEqual('/dir/')
 })
 
 it('uses colors by default', () => {
   delete process.env.NODE_ENV
-  let reporter = createReporter({ reporter: 'human' })
+  let reporter = createReporter({ logger: 'human' })
   expect(reporter.logger.chalk.level).toBeGreaterThan(0)
 })
 
 it('uses color in development', () => {
-  let reporter = createReporter({ env: 'development', reporter: 'human' })
+  let reporter = createReporter({ env: 'development', logger: 'human' })
   expect(reporter.logger.chalk.level).toBeGreaterThan(0)
 })
 
 it('uses environment variable to detect environment', () => {
   process.env.NODE_ENV = 'production'
-  let reporter = createReporter({ reporter: 'human' })
+  let reporter = createReporter({ logger: 'human' })
   expect(reporter.logger.chalk.level).toEqual(0)
 })
 

--- a/server/__snapshots__/index.test.ts.snap
+++ b/server/__snapshots__/index.test.ts.snap
@@ -29,7 +29,7 @@ exports[`shows help 1`] = `
   --port, -p        Port to bind server                                 [number]
   --key             Path to SSL key                                     [string]
   --cert            Path to SSL certificate                             [string]
-  --reporter, -r    Reporter type            [string] [choices: \\"human\\", \\"json\\"]
+  --logger, -l      Logger type              [string] [choices: \\"human\\", \\"json\\"]
   --backend         Backend to process actions and authentication       [string]
   --control-secret  Secret to control Logux server                      [string]
   --control-mask    CIDR masks for IP addresses of control servers      [string]
@@ -41,7 +41,7 @@ Examples:
   LOGUX_PORT=1337 options.js
 
 Environment variables:
-  LOGUX_HOST, LOGUX_PORT, LOGUX_KEY, LOGUX_CERT, LOGUX_REPORTER, LOGUX_REDIS
+  LOGUX_HOST, LOGUX_PORT, LOGUX_KEY, LOGUX_CERT, LOGUX_LOGGER, LOGUX_REDIS
   LOGUX_CONTROL_MASK, LOGUX_CONTROL_SECRET, LOGUX_BACKEND
 "
 `;
@@ -189,13 +189,13 @@ exports[`uses environment variables for config 1`] = `
 "
 `;
 
-exports[`uses reporter param 1`] = `
+exports[`uses logger param 1`] = `
 "{\\"level\\":30,\\"time\\":\\"1970-01-01T00:00:00.000Z\\",\\"pid\\":21384,\\"hostname\\":\\"localhost\\",\\"name\\":\\"logux-server\\",\\"loguxServer\\":\\"0.0.0\\",\\"environment\\":\\"test\\",\\"nodeId\\":\\"server:FnXaqDxY\\",\\"subprotocol\\":\\"1.0.0\\",\\"supports\\":\\"1.x\\",\\"listen\\":\\"ws://127.0.0.1:31337/\\",\\"msg\\":\\"Logux server is listening\\"}
 {\\"level\\":30,\\"time\\":\\"1970-01-01T00:00:00.000Z\\",\\"pid\\":21384,\\"hostname\\":\\"localhost\\",\\"name\\":\\"logux-server\\",\\"msg\\":\\"Shutting down Logux server\\"}
 "
 `;
 
-exports[`uses reporter param for constructor errors 1`] = `
+exports[`uses logger param for constructor errors 1`] = `
 "{\\"level\\":60,\\"time\\":\\"1970-01-01T00:00:00.000Z\\",\\"pid\\":21384,\\"hostname\\":\\"localhost\\",\\"name\\":\\"logux-server\\",\\"note\\":\\"Check server constructor and Logux Server documentation\\",\\"msg\\":\\"Missed \`supports\` option in server constructor\\"}
 "
 `;

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -2,7 +2,8 @@ import BaseServer, { Logger, Reporter, BaseServerOptions } from '../base-server'
 
 export type ServerOptions = BaseServerOptions & {
   /**
-   * Custom reporter for process/errors
+   * Custom reporter for process/errors. You should use it only for test purposes
+   * or unavoidable hacks.
    *
    * ```js
    * new Server({
@@ -76,7 +77,7 @@ export type ServerOptions = BaseServerOptions & {
  */
 export default class Server<H extends object = {}> extends BaseServer<H> {
   /**
-   * Load options from command-line arguments and/or environment
+   * Load options from command-line arguments and/or environment.
    *
    * ```js
    * const server = new Server(Server.loadOptions(process, {

--- a/server/index.d.ts
+++ b/server/index.d.ts
@@ -2,11 +2,19 @@ import BaseServer, { Logger, Reporter, BaseServerOptions } from '../base-server'
 
 export type ServerOptions = BaseServerOptions & {
   /**
-   * Report process/errors to CLI in pino JSON or in human readable
-   * format. It can be also a function to show current server status.
-   * Default is `'human'`.
+   * Custom reporter for process/errors
+   *
+   * ```js
+   * new Server({
+   *   …,
+   *   reporter: (name, details) => {
+   *     console.log('Event:', name)
+   *     console.log('Details:', JSON.stringify(details))
+   *   }
+   * })
+   * ```
    */
-  reporter?: 'human' | 'json' | Reporter
+  reporter?: Reporter
 
   /**
    * Stream to be used by reporter to write log.
@@ -18,7 +26,7 @@ export type ServerOptions = BaseServerOptions & {
   /**
    * Logger with custom settings.
    *
-   * For example, you can provide pino logger that streams logs to
+   * Custom logger example: pino logger that streams logs to
    * elasticsearch
    *
    * ```js
@@ -41,7 +49,7 @@ export type ServerOptions = BaseServerOptions & {
    *
    * Other logger examples can be found here http://getpino.io/#/docs/ecosystem
    */
-  logger?: Logger
+  logger?: 'human' | 'json' | Logger
 }
 
 /**

--- a/server/index.js
+++ b/server/index.js
@@ -32,7 +32,7 @@ const ENVS = {
   port: 'LOGUX_PORT',
   key: 'LOGUX_KEY',
   cert: 'LOGUX_CERT',
-  reporter: 'LOGUX_REPORTER',
+  logger: 'LOGUX_LOGGER',
   redis: 'LOGUX_REDIS',
   controlMask: 'LOGUX_CONTROL_MASK',
   controlSecret: 'LOGUX_CONTROL_SECRET',
@@ -72,9 +72,9 @@ yargs
     describe: 'Path to SSL certificate',
     type: 'string'
   })
-  .option('reporter', {
-    alias: 'r',
-    describe: 'Reporter type',
+  .option('logger', {
+    alias: 'l',
+    describe: 'Logger type',
     choices: ['human', 'json'],
     type: 'string'
   })
@@ -124,7 +124,7 @@ class Server extends BaseServer {
     if (!opts) opts = {}
 
     if (typeof opts.reporter !== 'function') {
-      opts.reporter = opts.reporter || 'human'
+      opts.logger = opts.logger || 'human'
       opts.reporter = createReporter(opts)
     }
 

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -100,7 +100,7 @@ it('uses CLI args for options', () => {
       '1337',
       '--host',
       '192.168.1.1',
-      '--reporter',
+      '--logger',
       'json',
       '--redis',
       '//localhost',
@@ -117,7 +117,7 @@ it('uses CLI args for options', () => {
 
   expect(options.host).toEqual('192.168.1.1')
   expect(options.port).toEqual(1337)
-  expect(options.reporter).toEqual('json')
+  expect(options.logger).toEqual('json')
   expect(options.cert).toBeUndefined()
   expect(options.key).toBeUndefined()
   expect(options.redis).toEqual('//localhost')
@@ -130,7 +130,7 @@ it('uses env for options', () => {
     fakeProcess([], {
       LOGUX_HOST: '127.0.1.1',
       LOGUX_PORT: '31337',
-      LOGUX_REPORTER: 'json',
+      LOGUX_LOGGER: 'json',
       LOGUX_REDIS: '//localhost',
       LOGUX_BACKEND: 'http://localhost:8080/logux',
       LOGUX_CONTROL_SECRET: 'secret'
@@ -143,7 +143,7 @@ it('uses env for options', () => {
 
   expect(options.host).toEqual('127.0.1.1')
   expect(options.port).toEqual(31337)
-  expect(options.reporter).toEqual('json')
+  expect(options.logger).toEqual('json')
   expect(options.redis).toEqual('//localhost')
   expect(options.backend).toEqual('http://localhost:8080/logux')
   expect(options.controlSecret).toEqual('secret')
@@ -200,14 +200,14 @@ it('uses environment variables for config', () => {
   return checkOut('options.js', [], {
     env: {
       ...process.env,
-      LOGUX_REPORTER: 'json',
+      LOGUX_LOGGER: 'json',
       LOGUX_PORT: '31337',
       NODE_ENV: 'test'
     }
   })
 })
 
-it('uses reporter param', () => checkOut('options.js', ['', '--r', 'json']))
+it('uses logger param', () => checkOut('options.js', ['', '--l', 'json']))
 
 it('uses autoload modules', () => checkOut('autoload-modules.js'))
 
@@ -251,8 +251,8 @@ it('disables colors for constructor errors', () => {
   })
 })
 
-it('uses reporter param for constructor errors', () => {
-  return checkError('missed.js', ['', '--r', 'json'])
+it('uses logger param for constructor errors', () => {
+  return checkError('missed.js', ['', '--l', 'json'])
 })
 
 it('writes to pino log', () => checkOut('pino.js'))

--- a/server/types.ts
+++ b/server/types.ts
@@ -6,7 +6,6 @@ import pino = require('pino')
 let server = new Server<{ locale: string }>(
   Server.loadOptions(process, {
     subprotocol: '1.0.0',
-    reporter: 'human',
     supports: '1.x',
     logger: pino({ name: 'logux' }),
     root: __dirname

--- a/test/servers/pino.js
+++ b/test/servers/pino.js
@@ -6,7 +6,7 @@ let app = new Server({
   subprotocol: '1.0.0',
   supports: '1.x',
   port: 2000,
-  reporter: 'pino'
+  logger: 'json'
 })
 app.nodeId = 'server:FnXaqDxY'
 


### PR DESCRIPTION
Actually 'human' and 'json' are logger types, not reporter.

At least this problem - 
> If we specify custom logger and human reporter, custom logger will also win and "human" reporter is ignored

is resolved.

This  problem
> If we specify custom logger and custom reporter, custom logger will be ignored
still exists

still persists. Maybe some warning can be issued when this situation encountered, alas, I found no examples of warnings, only errors.