### PR TITLE
Fix reporter creation in test-server

### DIFF
--- a/test-client/index.test.ts
+++ b/test-client/index.test.ts
@@ -170,7 +170,7 @@ it('prints server log', async () => {
     write () {}
   }
   jest.spyOn(reporterStream, 'write').mockImplementation(() => {})
-  server = new TestServer({ reporter: 'human', reporterStream })
+  server = new TestServer({ logger: 'human', reporterStream })
   await server.connect('10:uuid')
   expect(reporterStream.write).toHaveBeenCalledTimes(2)
 })

--- a/test-server/index.d.ts
+++ b/test-server/index.d.ts
@@ -22,7 +22,7 @@ export type TestServerOptions = Omit<
   /**
    * Print server log to the console for debug.
    */
-  reporter?: 'human' | Reporter
+  reporter?: Reporter
 
   /**
    * Stream to be used by reporter to write log.
@@ -30,6 +30,11 @@ export type TestServerOptions = Omit<
   reporterStream?: {
     write(str: string): void
   }
+
+  /**
+   * Print logs in human readable format
+   */
+  logger?: 'human'
 }
 
 /**

--- a/test-server/index.js
+++ b/test-server/index.js
@@ -9,7 +9,7 @@ class TestServer extends BaseServer {
     if (!opts.time) {
       opts.time = new TestTime()
     }
-    if (opts.reporter === 'human') {
+    if (opts.logger === 'human') {
       opts.reporter = createReporter(opts)
     }
     opts.time.lastId += 1


### PR DESCRIPTION
This is the most simple fix, but I don't like it. 

The only place when `'human'` is passed to `TestServer` in `logux/server` is [here](https://github.com/logux/server/blob/next/test-client/index.test.ts#L173). 
And it seems that we don't care about logs format (even test were not broken, though `'json'` logger was created actually after my reporter/logger api change), just want them to be written to provided stream.
So maybe we can remove `'human'` option and modify built-in reporter to use `reporterStream` if it's provided. (Current behaviour: when you provide `reporterStream` it's ignored if reporter is the default one)

I could try to implement my idea, the only obstacle that I don't know how `TestServer` is supposed to be used from outside.

