### PR TITLE
Feature: Allow regex in baseServer.type

### DIFF
--- a/base-server/index.d.ts
+++ b/base-server/index.d.ts
@@ -771,14 +771,14 @@ export default class BaseServer<
    * })
    * ```
    *
-   * @param name The action’s type.
+   * @param name The action’s type or action’s type matching rule as RegExp..
    * @param callbacks Callbacks for actions with this type.
    *
    * @template A Action’s type.
    * @template D Type for `ctx.data`.
    */
   type<A extends Action = AnyAction, D extends object = {}> (
-    name: A['type'],
+    name: A['type'] | RegExp,
     callbacks: ActionCallbacks<A, D, H>
   ): void
 
@@ -792,36 +792,6 @@ export default class BaseServer<
   type<AC extends ActionCreator, D extends object = {}> (
     actionCreator: AC,
     callbacks: ActionCallbacks<ReturnType<AC>, D, H>
-  ): void
-
-  /**
-   * Define action type’s callbacks with regex expression action name match.
-   *
-   * ```js
-   * server.type(\/^TODO.*\/, {
-   *   access (ctx, action, meta) {
-   *     return action.user === ctx.userId
-   *   },
-   *   resend (ctx, action) {
-   *     return { channel: `user/${ action.user }` }
-   *   }
-   *   process (ctx, action, meta) {
-   *     if (isFirstOlder(lastNameChange(action.user), meta)) {
-   *       return db.changeUserName({ id: action.user, name: action.name })
-   *     }
-   *   }
-   * })
-   * ```
-   *
-   * @param regex The action’s type matching rule as RegExp.
-   * @param callbacks Callbacks for actions with this type.
-   *
-   * @template A Action’s type.
-   * @template D Type for `ctx.data`.
-   */
-  type<A extends Action = AnyAction, D extends object = {}> (
-    regex: RegExp,
-    callbacks: ActionCallbacks<A, D, H>
   ): void
 
   /**

--- a/base-server/index.d.ts
+++ b/base-server/index.d.ts
@@ -778,7 +778,7 @@ export default class BaseServer<
    * @template D Type for `ctx.data`.
    */
   type<A extends Action = AnyAction, D extends object = {}> (
-    name: A['type'],
+    name: A['type'] | RegExp,
     callbacks: ActionCallbacks<A, D, H>
   ): void
 

--- a/base-server/index.d.ts
+++ b/base-server/index.d.ts
@@ -778,7 +778,7 @@ export default class BaseServer<
    * @template D Type for `ctx.data`.
    */
   type<A extends Action = AnyAction, D extends object = {}> (
-    name: A['type'] | RegExp,
+    name: A['type'],
     callbacks: ActionCallbacks<A, D, H>
   ): void
 
@@ -792,6 +792,36 @@ export default class BaseServer<
   type<AC extends ActionCreator, D extends object = {}> (
     actionCreator: AC,
     callbacks: ActionCallbacks<ReturnType<AC>, D, H>
+  ): void
+
+  /**
+   * Define action type’s callbacks with regex expression action name match.
+   *
+   * ```js
+   * server.type(\/^TODO.*\/, {
+   *   access (ctx, action, meta) {
+   *     return action.user === ctx.userId
+   *   },
+   *   resend (ctx, action) {
+   *     return { channel: `user/${ action.user }` }
+   *   }
+   *   process (ctx, action, meta) {
+   *     if (isFirstOlder(lastNameChange(action.user), meta)) {
+   *       return db.changeUserName({ id: action.user, name: action.name })
+   *     }
+   *   }
+   * })
+   * ```
+   *
+   * @param regex The action’s type matching rule as RegExp.
+   * @param callbacks Callbacks for actions with this type.
+   *
+   * @template A Action’s type.
+   * @template D Type for `ctx.data`.
+   */
+  regexType<A extends Action = AnyAction, D extends object = {}> (
+    regex: RegExp,
+    callbacks: ActionCallbacks<A, D, H>
   ): void
 
   /**

--- a/base-server/index.d.ts
+++ b/base-server/index.d.ts
@@ -819,7 +819,7 @@ export default class BaseServer<
    * @template A Action’s type.
    * @template D Type for `ctx.data`.
    */
-  regexType<A extends Action = AnyAction, D extends object = {}> (
+  type<A extends Action = AnyAction, D extends object = {}> (
     regex: RegExp,
     callbacks: ActionCallbacks<A, D, H>
   ): void

--- a/base-server/index.js
+++ b/base-server/index.js
@@ -84,7 +84,12 @@ class BaseServer {
         if (!meta.subprotocol) {
           meta.subprotocol = this.options.subprotocol
         }
-        if (!this.options.backend && !this.types[action.type] && !isLogux) {
+        if (
+          !this.options.backend &&
+          !this.types[action.type] &&
+          !this.getRegexProcessor(action.type) &&
+          !isLogux
+        ) {
           meta.status = 'processed'
         }
       }
@@ -701,7 +706,11 @@ class BaseServer {
   }
 
   isUseless (action, meta) {
-    if (meta.status !== 'processed' || this.types[action.type]) {
+    if (
+      meta.status !== 'processed' ||
+      this.types[action.type] ||
+      this.getRegexProcessor(action.type)
+    ) {
       return false
     }
     for (let i of ['channels', 'nodes', 'clients', 'users']) {

--- a/base-server/index.js
+++ b/base-server/index.js
@@ -333,24 +333,24 @@ class BaseServer {
   }
 
   type (name, callbacks) {
-    if (typeof name === 'function') name = name.toString()
-    if (this.types[name]) {
-      throw new Error(`Action type ${name} was already defined`)
+    if (name instanceof RegExp) {
+      if (this.regexTypes[name]) {
+        throw new Error(`Action type ${name} was already defined`)
+      }
+      if (!callbacks || !callbacks.access) {
+        throw new Error(`Action type ${name} must have access callback`)
+      }
+      this.regexTypes[name] = callbacks
+    } else {
+      if (typeof name === 'function') name = name.toString()
+      if (this.types[name]) {
+        throw new Error(`Action type ${name} was already defined`)
+      }
+      if (!callbacks || !callbacks.access) {
+        throw new Error(`Action type ${name} must have access callback`)
+      }
+      this.types[name] = callbacks
     }
-    if (!callbacks || !callbacks.access) {
-      throw new Error(`Action type ${name} must have access callback`)
-    }
-    this.types[name] = callbacks
-  }
-
-  regexType (name, callbacks) {
-    if (this.regexTypes[name]) {
-      throw new Error(`Action type ${name} was already defined`)
-    }
-    if (!callbacks || !callbacks.access) {
-      throw new Error(`Action type ${name} must have access callback`)
-    }
-    this.regexTypes[name] = callbacks
   }
 
   otherType (callbacks) {

--- a/base-server/index.js
+++ b/base-server/index.js
@@ -720,7 +720,9 @@ class BaseServer {
     if (processor) {
       return processor
     } else {
-      return this.otherProcessor
+      let regexps = Object.keys(this.types).filter(key => key.startsWith('/') && key.endsWith('/') && key.length > 1)
+      let match = regexps.find(regexp => type.match(regexp.substr(1, regexp.length - 2)) !== null)
+      return match !== undefined ? this.types[match] : this.otherProcessor
     }
   }
 

--- a/base-server/index.test.ts
+++ b/base-server/index.test.ts
@@ -447,8 +447,9 @@ it('defines actions types', () => {
 
 it('defines regex matching actions types', () => {
   let app = createServer()
-  app.type(/.*TODO$/, { access: () => true })
-  expect(privateMethods(app).regexTypes['/.*TODO$/']).not.toBeUndefined()
+  let pattern = /.*TODO$/
+  app.type(pattern, { access: () => true })
+  expect(privateMethods(app).regexTypes.has(pattern)).toBe(true)
 })
 
 it('does not allow to define type twice', () => {
@@ -456,14 +457,6 @@ it('does not allow to define type twice', () => {
   app.type('FOO', { access: () => true })
   expect(() => {
     app.type('FOO', { access: () => true })
-  }).toThrow(/already/)
-})
-
-it('does not allow to define regexType twice', () => {
-  let app = createServer()
-  app.type(/.*TODO$/, { access: () => true })
-  expect(() => {
-    app.type(/.*TODO$/, { access: () => true })
   }).toThrow(/already/)
 })
 

--- a/base-server/index.test.ts
+++ b/base-server/index.test.ts
@@ -445,6 +445,12 @@ it('defines actions types', () => {
   expect(privateMethods(app).types.FOO).not.toBeUndefined()
 })
 
+it('defines regex matching actions types', () => {
+  let app = createServer()
+  app.regexType(/.*TODO$/, { access: () => true })
+  expect(privateMethods(app).regexTypes['/.*TODO$/']).not.toBeUndefined()
+})
+
 it('does not allow to define type twice', () => {
   let app = createServer()
   app.type('FOO', { access: () => true })
@@ -453,11 +459,27 @@ it('does not allow to define type twice', () => {
   }).toThrow(/already/)
 })
 
+it('does not allow to define regexType twice', () => {
+  let app = createServer()
+  app.regexType(/.*TODO$/, { access: () => true })
+  expect(() => {
+    app.regexType(/.*TODO$/, { access: () => true })
+  }).toThrow(/already/)
+})
+
 it('requires access callback for type', () => {
   let app = createServer()
   expect(() => {
     // @ts-expect-error
     app.type('FOO')
+  }).toThrow(/access callback/)
+})
+
+it('requires access callback for regexType', () => {
+  let app = createServer()
+  expect(() => {
+    // @ts-expect-error
+    app.regexType(/.*TODO$/)
   }).toThrow(/access callback/)
 })
 

--- a/base-server/index.test.ts
+++ b/base-server/index.test.ts
@@ -447,7 +447,7 @@ it('defines actions types', () => {
 
 it('defines regex matching actions types', () => {
   let app = createServer()
-  app.regexType(/.*TODO$/, { access: () => true })
+  app.type(/.*TODO$/, { access: () => true })
   expect(privateMethods(app).regexTypes['/.*TODO$/']).not.toBeUndefined()
 })
 
@@ -461,9 +461,9 @@ it('does not allow to define type twice', () => {
 
 it('does not allow to define regexType twice', () => {
   let app = createServer()
-  app.regexType(/.*TODO$/, { access: () => true })
+  app.type(/.*TODO$/, { access: () => true })
   expect(() => {
-    app.regexType(/.*TODO$/, { access: () => true })
+    app.type(/.*TODO$/, { access: () => true })
   }).toThrow(/already/)
 })
 
@@ -479,7 +479,7 @@ it('requires access callback for regexType', () => {
   let app = createServer()
   expect(() => {
     // @ts-expect-error
-    app.regexType(/.*TODO$/)
+    app.type(/.*TODO$/)
   }).toThrow(/access callback/)
 })
 
@@ -582,7 +582,7 @@ it('processes regex matching action', async () => {
   let processed: Action[] = []
   let fired: Action[] = []
 
-  test.app.regexType(/.*TODO$/, {
+  test.app.type(/.*TODO$/, {
     access: () => true,
     async process (ctx, action, meta) {
       expect(meta.added).toEqual(1)

--- a/bind-backend-proxy/index.js
+++ b/bind-backend-proxy/index.js
@@ -92,7 +92,7 @@ function bindBackendProxy (app) {
         )
       },
       command ({ action, meta }, req) {
-        if (!app.types[action.type]) {
+        if (!app.types[action.type] && !app.getRegexProcessor(action.type)) {
           meta.status = 'processed'
         }
         meta.backend = req.connection.remoteAddress

--- a/server/errors.ts
+++ b/server/errors.ts
@@ -79,7 +79,7 @@ server.type('user/changeId', {
   }
 })
 
-// THROWS '"bad"' is not assignable to parameter of type '"user/rename"'
+// THROWS Argument of type '"bad"' is not assignable to parameter of type 'RegExp | "user/rename"'
 server.type<UserRenameAction>('bad', {
   access () {
     return true


### PR DESCRIPTION
**Motivation**:
Ability to specify a single processor for a set of actions. Like:

```ts
server.type(/.*TODO.*/, {
    access: function (ctx, action, meta) {
        return true;
    },
    resend: function (ctx, action, meta) {
        // Resend this action to everyone who subscribed to this user
        return { channel: "GLOBAL_TEST" };
    },
    process: function (ctx, action, meta) {
        // process
    },
    finally: function (ctx, action, meta) {
        // finally
    }
});
```

where all actions containing TODO in its name will be processed.
This small PR parses regex from types keys as long as actionName directly does not match.