### PR TITLE
Replace yargs with custom args parser

### DIFF
--- a/options-loader/__snapshots__/index.test.ts.snap
+++ b/options-loader/__snapshots__/index.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`loadOptions returns help 1`] = `
+"[1mOptions:[22m
+[33m[39m[33m--port     [39m[36m     [39mport
+
+[1mExamples:[22m
+test.js"
+`;
+
+exports[`loadOptions throws on missing values 1`] = `
+"Failed to parse [1mport[22m argument value. 
+Expected [32mstring[39m, got [31mtrue[39m"
+`;
+
+exports[`loadOptions throws on unknown args 1`] = `"Unknown argument: --unknown"`;
+
+exports[`loadOptions throws on unparsed args 1`] = `
+"Failed to parse [1mport[22m argument value. 
+Expected [32mnumber[39m, got [31mW_W[39m"
+`;
+
+exports[`parsers number should return error on invalid values 1`] = `"Expected [32mnumber[39m, got [31mnot a number[39m"`;
+
+exports[`parsers oneOf should return error on invalid values 1`] = `"Expected [32mone of [\\"1\\",\\"2\\"][39m, got [31m3[39m"`;

--- a/options-loader/errors.ts
+++ b/options-loader/errors.ts
@@ -1,28 +1,5 @@
 import { loadOptions, CliOptionsSpec, CliOptionSpec } from './index.js'
 
-const optionsSpec: CliOptionsSpec<{
-  minimalCliArgument: string
-  fullBlownCliArgument: number
-}> = {
-  options: {
-    minimalCliArgument: {
-      description: 'Some valuable cli parameter'
-    },
-    fullBlownCliArgument: {
-      alias: 'f',
-      description: 'Some valuable cli parameter',
-      parse: rawValue => Number.parseInt(rawValue)
-    }
-  },
-  examples: ['test'],
-  envPrefix: 'LOGUX'
-}
-
-// THROWS Type 'string' is not assignable to type 'number | undefined'
-loadOptions(optionsSpec, process, {}, { fullBlownCliArgument: '12' })
-// THROWS Argument of type '{ unknownArgument: string; }' is not assignable to parameter of type 'Partial<{ minimalCliArgument: string; fullBlownCliArgument: number; }>'
-loadOptions(optionsSpec, process, {}, { unknownArgument: '12' })
-
 const wronglyParsedOption: CliOptionSpec<number> = {
   // THROWS Type '(rawValue: string) => string' is not assignable to type '(rawValue: string) => number'
   parse: (rawValue) => rawValue

--- a/options-loader/errors.ts
+++ b/options-loader/errors.ts
@@ -1,0 +1,34 @@
+import { loadOptions, CliOptionsSpec, CliOptionSpec } from './index.js'
+
+const optionsSpec: CliOptionsSpec<{
+  minimalCliArgument: string
+  fullBlownCliArgument: number
+}> = {
+  options: {
+    minimalCliArgument: {
+      description: 'Some valuable cli parameter'
+    },
+    fullBlownCliArgument: {
+      alias: 'f',
+      description: 'Some valuable cli parameter',
+      parse: rawValue => Number.parseInt(rawValue)
+    }
+  },
+  examples: ['test'],
+  envPrefix: 'LOGUX'
+}
+
+// THROWS Type 'string' is not assignable to type 'number | undefined'
+loadOptions(optionsSpec, process, {}, { fullBlownCliArgument: '12' })
+// THROWS Argument of type '{ unknownArgument: string; }' is not assignable to parameter of type 'Partial<{ minimalCliArgument: string; fullBlownCliArgument: number; }>'
+loadOptions(optionsSpec, process, {}, { unknownArgument: '12' })
+
+const wronglyParsedOption: CliOptionSpec<number> = {
+  // THROWS Type '(rawValue: string) => string' is not assignable to type '(rawValue: string) => number'
+  parse: (rawValue) => rawValue
+}
+
+// THROWS Property 'description' is missing in type '{ alias: string; }' but required in type 'CliOptionSpec<number>'.
+const missingDescriptionOption: CliOptionSpec<number> = {
+  alias: '0'
+}

--- a/options-loader/index.d.ts
+++ b/options-loader/index.d.ts
@@ -1,0 +1,24 @@
+import { DotenvConfigOptions } from 'dotenv'
+
+export type CliOptionSpec<T = string> = {
+  alias?: string
+  description: string
+  parse?: (rawValue: string) => T
+}
+
+export type CliOptionsSpec<T extends Record<string, any>> = {
+  options: {
+    [Key in keyof T]: CliOptionSpec<T[Key]>
+  }
+  envPrefix?: string
+  examples?: string[]
+}
+
+export function loadOptions<T extends Record<string, any>> (
+  spec: CliOptionsSpec<T>,
+  process: NodeJS.Process,
+  env?: DotenvConfigOptions,
+  defaults?: Partial<T>
+): T
+
+export function oneOf (choices: string[], rawValue: unknown): string | null

--- a/options-loader/index.d.ts
+++ b/options-loader/index.d.ts
@@ -17,8 +17,11 @@ export type CliOptionsSpec<T extends Record<string, any>> = {
 export function loadOptions<T extends Record<string, any>> (
   spec: CliOptionsSpec<T>,
   process: NodeJS.Process,
-  env?: DotenvConfigOptions,
-  defaults?: Partial<T>
-): T
+  env?: DotenvConfigOptions
+): [string, null] | [null, T]
 
-export function oneOf (choices: string[], rawValue: unknown): string | null
+export function oneOf<T> (choices: T, rawValue: string): ParsingResult<T>
+
+export function number (rawValue: string): ParsingResult<number>
+
+type ParsingResult<T> = [string, null] | [null, T]

--- a/options-loader/index.js
+++ b/options-loader/index.js
@@ -1,0 +1,160 @@
+import { yellow, cyan, bold } from 'colorette'
+import dotenv from 'dotenv'
+
+export function loadOptions (spec, process, env, defaults) {
+  let rawCliArgs = gatherCliArgs(process.argv)
+  if (rawCliArgs['--help']) {
+    console.log(composeHelp(spec, process.argv))
+    process.exit(0)
+  }
+
+  let namesMap = {}
+  for (let key in spec.options) {
+    let option = spec.options[key]
+    namesMap[composeCliFullName(key)] = key
+    namesMap[composeEnvName(spec.envPrefix, key)] = key
+    if (option.alias) {
+      namesMap[composeCliAliasName(option.alias)] = key
+    }
+  }
+
+  let cliArgs = parseValues(spec, mapArgs(rawCliArgs, namesMap))
+  let envArgs = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) =>
+      key.startsWith(spec.envPrefix)
+    )
+  )
+  envArgs = parseValues(
+    spec,
+    mapArgs(Object.assign(envArgs, parseEnvArgs(env)), namesMap)
+  )
+  let opts = {}
+  for (let key in spec.options) {
+    let maybeValue = cliArgs[key] || envArgs[key] || defaults[key]
+    if (maybeValue !== undefined) {
+      opts[key] = maybeValue
+    }
+  }
+  return opts
+}
+
+function gatherCliArgs (argv) {
+  let args = {}
+  let key = null
+  let value = []
+  for (let it of argv) {
+    if (it.startsWith('-')) {
+      if (key) {
+        args[key] = value
+        value = []
+      }
+      key = it
+    } else if (key) {
+      value = [...value, it]
+    }
+  }
+  if (key) {
+    args[key] = value
+  }
+  for (let k in args) {
+    if (args[k].length === 0) {
+      args[k] = true
+    } else if (args[k].length === 1) {
+      args[k] = args[k][0]
+    }
+  }
+  return args
+}
+
+function parseValues (spec, args) {
+  let parsed = { ...args }
+  for (let key in args) {
+    if (spec.options[key].parse) {
+      parsed[key] = spec.options[key].parse(args[key])
+    }
+  }
+  return parsed
+}
+
+function parseEnvArgs (file) {
+  return dotenv.config(file).parsed
+}
+
+function mapArgs (parsedCliArgs, argsSpec) {
+  return Object.fromEntries(
+    Object.entries(parsedCliArgs).map(([name, value]) => {
+      if (!argsSpec[name]) {
+        let error = new Error(`Unknown argument: ${name}`)
+        error.arg = name
+        throw error
+      }
+      return [argsSpec[name], value]
+    })
+  )
+}
+
+function composeHelp (spec, argv) {
+  let options = Object.entries(spec.options).map(([name, option]) => ({
+    alias: option.alias ? composeCliAliasName(option.alias) : '',
+    full: composeCliFullName(name),
+    env: (spec.envPrefix && composeEnvName(spec.envPrefix, name)) || '',
+    description: option.description
+  }))
+  let aliasColumnLength = Math.max(...options.map(it => it.alias.length))
+  let nameColumnLength = Math.max(...options.map(it => it.full.length))
+  let envColumnLength = Math.max(...options.map(it => it.env.length))
+
+  let composeAlias = alias =>
+    yellow(alias.padEnd(aliasColumnLength && aliasColumnLength + 3))
+  let composeName = name => yellow(name.padEnd(nameColumnLength + 5))
+  let composeEnv = env => cyan(env.padEnd(envColumnLength + 5))
+  let composeOptionHelp = option => {
+    return `${composeAlias(option.alias)}${composeName(
+      option.full
+    )}${composeEnv(option.env)}${option.description}`
+  }
+
+  let examples = []
+  if (spec.examples) {
+    let pathParts = argv[1].split('/')
+    examples = [
+      bold('Examples:'),
+      ...spec.examples.map(it =>
+        it.replace('$0', pathParts[pathParts.length - 1])
+      )
+    ]
+  }
+
+  return [
+    bold('Options:'),
+    ...options.map(option => composeOptionHelp(option)),
+    ...examples
+  ].join('\n')
+}
+
+function composeEnvName (prefix, name) {
+  return `${prefix}_${name.replace(
+    /[A-Z]/g,
+    match => '_' + match
+  )}`.toUpperCase()
+}
+
+function composeCliFullName (name) {
+  return `--${toKebabCase(name)}`
+}
+
+function composeCliAliasName (name) {
+  return `-${name}`
+}
+
+function toKebabCase (word) {
+  return word.replace(/[A-Z]/, match => `-${match.toLowerCase()}`)
+}
+
+export function oneOf (options, value) {
+  if (!options.includes(value)) {
+    throw new Error(`Expected one of ${JSON.stringify(options)}, got ${value}`)
+  } else {
+    return value
+  }
+}

--- a/options-loader/index.test.ts
+++ b/options-loader/index.test.ts
@@ -1,0 +1,238 @@
+import { loadOptions, oneOf, number } from './index.js'
+
+function fakeProcess (argv: string[] = [], env: object = {}): any {
+  return {
+    argv,
+    env
+  }
+}
+
+describe('loadOptions', () => {
+  it('returns help', () => {
+    let [help, options] = loadOptions(
+      {
+        options: {
+          port: {
+            description: 'port',
+            parse: number
+          }
+        },
+        examples: ['$0']
+      },
+      fakeProcess(['node', 'test/test.js', '--help'])
+    )
+
+    expect(help).toMatchSnapshot()
+    expect(options).toBeNull()
+  })
+
+  it('uses CLI args for options', () => {
+    let [, options] = loadOptions(
+      {
+        options: {
+          port: {
+            description: 'port',
+            parse: number
+          }
+        }
+      },
+      fakeProcess(['', '--port', '1337'])
+    )
+    expect(options?.port).toEqual(1337)
+  })
+
+  it('uses env for options', () => {
+    let [, options] = loadOptions(
+      {
+        options: {
+          port: {
+            description: 'port',
+            parse: number
+          }
+        },
+        envPrefix: 'LOGUX'
+      },
+      fakeProcess([], {
+        LOGUX_PORT: '31337'
+      }),
+      {}
+    )
+
+    expect(options?.port).toEqual(31337)
+  })
+
+  it('composes correct env and CLI names for argument with complex name', () => {
+    let [, options] = loadOptions(
+      {
+        options: {
+          somePort: {
+            description: 'port',
+            parse: number
+          }
+        },
+        envPrefix: 'LOGUX'
+      },
+      fakeProcess(['--some-port', '1'], {
+        LOGUX_SOME_PORT: '1'
+      }),
+      {}
+    )
+
+    expect(options?.somePort).toEqual(1)
+  })
+
+  it('uses combined options', () => {
+    let [, options] = loadOptions(
+      {
+        options: {
+          key: {
+            description: 'port'
+          },
+          cert: {
+            description: 'cert'
+          }
+        },
+        envPrefix: 'LOGUX'
+      },
+      fakeProcess(['', '--key', './key.pem'], { LOGUX_CERT: './cert.pem' })
+    )
+
+    expect(options?.cert).toEqual('./cert.pem')
+    expect(options?.key).toEqual('./key.pem')
+  })
+
+  it('uses arg and env in given priority', () => {
+    let optionsSpec = {
+      options: {
+        port: {
+          description: 'port',
+          parse: number
+        },
+        key: {
+          description: 'key'
+        },
+        cert: {
+          description: 'cert'
+        }
+      },
+      envPrefix: 'LOGUX'
+    }
+
+    let [, options1] = loadOptions(
+      optionsSpec,
+      fakeProcess(['', '--port', '3'], { LOGUX_PORT: '2' }),
+      undefined
+    )
+    let [, options2] = loadOptions(
+      optionsSpec,
+      fakeProcess([], { LOGUX_PORT: '2' }),
+      undefined
+    )
+
+    expect(options1?.port).toEqual(3)
+    expect(options2?.port).toEqual(2)
+  })
+
+  it('parses aliases', () => {
+    let [, options] = loadOptions(
+      {
+        options: {
+          port: {
+            alias: 'p',
+            description: 'port'
+          }
+        }
+      },
+      fakeProcess(['', '-p', '1'])
+    )
+    expect(options?.port).toEqual('1')
+  })
+
+  it('parses multiple args', () => {
+    let [, options] = loadOptions(
+      {
+        options: {
+          port: {
+            alias: 'p',
+            description: 'port'
+          },
+          key: {
+            description: 'key'
+          }
+        }
+      },
+      fakeProcess(['', '-p', '1', '--key', '1'])
+    )
+    expect(options?.port).toEqual('1')
+    expect(options?.key).toEqual('1')
+  })
+
+  it('throws on missing values', () => {
+    expect(() =>
+      loadOptions(
+        {
+          options: {
+            port: {
+              description: 'port'
+            }
+          }
+        },
+        fakeProcess(['', '--port'])
+      )
+    ).toThrowErrorMatchingSnapshot()
+  })
+
+  it('throws on unknown args', () => {
+    expect(() =>
+      loadOptions(
+        {
+          options: {
+            port: {
+              description: 'port'
+            }
+          }
+        },
+        fakeProcess(['', '--unknown', '1'])
+      )
+    ).toThrowErrorMatchingSnapshot()
+  })
+
+  it('throws on unparsed args', () => {
+    expect(() =>
+      loadOptions(
+        {
+          options: {
+            port: {
+              description: 'port',
+              parse: number
+            }
+          }
+        },
+        fakeProcess(['', '--port', 'W_W'])
+      )
+    ).toThrowErrorMatchingSnapshot()
+  })
+})
+
+describe('parsers', () => {
+  describe('oneOf', () => {
+    it('should return error on invalid values', () => {
+      let result = oneOf(['1', '2'], '3')
+      expect(result[0]).toMatchSnapshot()
+    })
+    it('should return null on correct values', () => {
+      expect(oneOf(['1', '2'], '1')).toEqual([null, '1'])
+    })
+  })
+
+  describe('number', () => {
+    it('should return error on invalid values', () => {
+      let result = number('not a number')
+      expect(result[0]).toMatchSnapshot()
+    })
+    it('should return null on correct values', () => {
+      expect(number('1')).toEqual([null, 1])
+      expect(number('1why parseInt is so permissive')).toEqual([null, 1])
+    })
+  })
+})

--- a/options-loader/types.ts
+++ b/options-loader/types.ts
@@ -18,4 +18,4 @@ const optionsSpec: CliOptionsSpec<{
   envPrefix: 'LOGUX'
 }
 
-loadOptions(optionsSpec, process, {}, { fullBlownCliArgument: 1 })
+loadOptions(optionsSpec, process, {})

--- a/options-loader/types.ts
+++ b/options-loader/types.ts
@@ -1,0 +1,21 @@
+import { loadOptions, CliOptionsSpec } from './index.js'
+
+const optionsSpec: CliOptionsSpec<{
+  minimalCliArgument: string
+  fullBlownCliArgument: number
+}> = {
+  options: {
+    minimalCliArgument: {
+      description: 'Some valuable cli parameter'
+    },
+    fullBlownCliArgument: {
+      alias: 'f',
+      description: 'Some valuable cli parameter',
+      parse: rawValue => Number.parseInt(rawValue)
+    }
+  },
+  examples: ['test'],
+  envPrefix: 'LOGUX'
+}
+
+loadOptions(optionsSpec, process, {}, { fullBlownCliArgument: 1 })

--- a/server/__snapshots__/index.test.ts.snap
+++ b/server/__snapshots__/index.test.ts.snap
@@ -26,27 +26,21 @@ exports[`disables colors for constructor errors 1`] = `
 
 exports[`shows help 1`] = `
 "Options:
-  -h, --host            Host to bind server.                            [string]
-  -p, --port            Port to bind server                             [number]
-      --key             Path to SSL key                                 [string]
-      --cert            Path to SSL certificate                         [string]
-      --supports        Range of supported client subprotocols          [string]
-      --subprotocol     Server subprotocol                              [string]
-  -l, --logger          Logger type          [string] [choices: \\"human\\", \\"json\\"]
-      --backend         Backend to process actions and authentication   [string]
-      --control-secret  Secret to control Logux server                  [string]
-      --control-mask    CIDR masks for IP addresses of control servers  [string]
-      --redis           URL to Redis for Logux Server Pro scaling       [string]
-      --help            Show help                                      [boolean]
+-h  --host               LOGUX_HOST               Host to bind server
+-p  --port               LOGUX_PORT               Port to bind server
+    --key                LOGUX_KEY                Path to SSL key
+    --cert               LOGUX_CERT               Path to SSL certificate
+    --supports           LOGUX_SUPPORTS           Range of supported client subprotocols
+    --subprotocol        LOGUX_SUBPROTOCOL        Server subprotocol
+-l  --logger             LOGUX_LOGGER             Logger type
+    --backend            LOGUX_BACKEND            Backend to process actions and authentication
+    --control-secret     LOGUX_CONTROL_SECRET     Secret to control Logux server
+    --control-mask       LOGUX_CONTROL_MASK       CIDR masks for IP addresses of control servers
+    --redis              LOGUX_REDIS              URL to Redis for Logux Server Pro scaling
 
 Examples:
-  options.js --port 31337 --host 127.0.0.1
-  LOGUX_PORT=1337 options.js
-
-Environment variables:
-  LOGUX_HOST, LOGUX_PORT, LOGUX_KEY, LOGUX_CERT, LOGUX_LOGGER, LOGUX_REDIS
-  LOGUX_SUPPORTS, LOGUX_SUBPROTOCOL, LOGUX_CONTROL_MASK, LOGUX_CONTROL_SECRET
-  LOGUX_BACKEND
+options.js --port 31337 --host 127.0.0.1
+LOGUX_PORT=1337 options.js
 "
 `;
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,9 +1,10 @@
 import { join, relative } from 'path'
 import globby from 'globby'
+import { bgRed, black } from 'colorette'
 
 import { createReporter } from '../create-reporter/index.js'
 import { BaseServer } from '../base-server/index.js'
-import { loadOptions, oneOf } from '../options-loader/index.js'
+import { loadOptions, oneOf, number } from '../options-loader/index.js'
 
 let cliOptionsSpec = {
   options: {
@@ -14,7 +15,7 @@ let cliOptionsSpec = {
     port: {
       alias: 'p',
       description: 'Port to bind server',
-      parse: it => Number.parseInt(it, 10)
+      parse: number
     },
     key: {
       description: 'Path to SSL key'
@@ -52,12 +53,22 @@ let cliOptionsSpec = {
 
 export class Server extends BaseServer {
   static loadOptions (process, defaults) {
-    return loadOptions(
+    let [help, options] = loadOptions(
       cliOptionsSpec,
       process,
-      defaults.root ? { path: join(defaults.root, '.env') } : undefined,
-      defaults
+      defaults.root ? { path: join(defaults.root, '.env') } : undefined
     )
+    if (help) {
+      console.log(help)
+      process.exit(0)
+    } else {
+      try {
+        return Object.assign(defaults, options)
+      } catch (e) {
+        console.error(`${bgRed(black(' ERROR '))} ${e.message}`)
+        process.exit(1)
+      }
+    }
   }
 
   constructor (opts = {}) {

--- a/server/index.js
+++ b/server/index.js
@@ -1,144 +1,70 @@
 import { join, relative } from 'path'
-import buildYargs from 'yargs'
-import dotenv from 'dotenv'
 import globby from 'globby'
 
 import { createReporter } from '../create-reporter/index.js'
 import { BaseServer } from '../base-server/index.js'
+import { loadOptions, oneOf } from '../options-loader/index.js'
 
-const AVAILABLE_OPTIONS = [
-  'subprotocol',
-  'supports',
-  'timeout',
-  'ping',
-  'root',
-  'store',
-  'server',
-  'port',
-  'host',
-  'key',
-  'cert',
-  'env',
-  'logger',
-  'backend',
-  'controlMask',
-  'controlSecret',
-  'redis',
-  'fileUrl'
-]
-
-const ENVS = {
-  host: 'LOGUX_HOST',
-  port: 'LOGUX_PORT',
-  key: 'LOGUX_KEY',
-  cert: 'LOGUX_CERT',
-  logger: 'LOGUX_LOGGER',
-  redis: 'LOGUX_REDIS',
-  supports: 'LOGUX_SUPPORTS',
-  subprotocol: 'LOGUX_SUBPROTOCOL',
-  controlMask: 'LOGUX_CONTROL_MASK',
-  controlSecret: 'LOGUX_CONTROL_SECRET',
-  backend: 'LOGUX_BACKEND'
-}
-
-function envHelp () {
-  let lines = ['  ']
-  for (let key in ENVS) {
-    if (lines[lines.length - 1].length + ENVS[key].length + 2 > 80) {
-      lines.push('  ')
+let cliOptionsSpec = {
+  options: {
+    host: {
+      alias: 'h',
+      description: 'Host to bind server'
+    },
+    port: {
+      alias: 'p',
+      description: 'Port to bind server',
+      parse: it => Number.parseInt(it, 10)
+    },
+    key: {
+      description: 'Path to SSL key'
+    },
+    cert: {
+      description: 'Path to SSL certificate'
+    },
+    supports: {
+      description: 'Range of supported client subprotocols'
+    },
+    subprotocol: {
+      description: 'Server subprotocol'
+    },
+    logger: {
+      alias: 'l',
+      description: 'Logger type',
+      parse: value => oneOf(['human', 'json'], value)
+    },
+    backend: {
+      description: 'Backend to process actions and authentication'
+    },
+    controlSecret: {
+      description: 'Secret to control Logux server'
+    },
+    controlMask: {
+      description: 'CIDR masks for IP addresses of control servers'
+    },
+    redis: {
+      description: 'URL to Redis for Logux Server Pro scaling'
     }
-    if (lines[lines.length - 1].length > 2) {
-      lines[lines.length - 1] += ', '
-    }
-    lines[lines.length - 1] += ENVS[key]
-  }
-  return lines.join('\n')
+  },
+  envPrefix: 'LOGUX',
+  examples: ['$0 --port 31337 --host 127.0.0.1', 'LOGUX_PORT=1337 $0']
 }
-
-let yargs = buildYargs()
-
-yargs
-  .option('host', {
-    alias: 'h',
-    describe: 'Host to bind server.',
-    type: 'string'
-  })
-  .option('port', {
-    alias: 'p',
-    describe: 'Port to bind server',
-    type: 'number'
-  })
-  .option('key', {
-    describe: 'Path to SSL key ',
-    type: 'string'
-  })
-  .option('cert', {
-    describe: 'Path to SSL certificate',
-    type: 'string'
-  })
-  .option('supports', {
-    describe: 'Range of supported client subprotocols',
-    type: 'string'
-  })
-  .option('subprotocol', {
-    describe: 'Server subprotocol',
-    type: 'string'
-  })
-  .option('logger', {
-    alias: 'l',
-    describe: 'Logger type',
-    choices: ['human', 'json'],
-    type: 'string'
-  })
-  .option('backend', {
-    describe: 'Backend to process actions and authentication',
-    type: 'string'
-  })
-  .option('control-secret', {
-    describe: 'Secret to control Logux server',
-    type: 'string'
-  })
-  .option('control-mask', {
-    describe: 'CIDR masks for IP addresses of control servers',
-    type: 'string'
-  })
-  .option('redis', {
-    describe: 'URL to Redis for Logux Server Pro scaling',
-    type: 'string'
-  })
-  .epilog(`Environment variables: \n${envHelp()}`)
-  .example('$0 --port 31337 --host 127.0.0.1')
-  .example('LOGUX_PORT=1337 $0')
-  .locale('en')
-  .help()
-  .version(false)
 
 export class Server extends BaseServer {
   static loadOptions (process, defaults) {
-    if (defaults.root) {
-      dotenv.config({ path: join(defaults.root, '.env') })
-    } else {
-      dotenv.config()
-    }
-    let argv = yargs.parse(process.argv)
-    let opts = {}
-
-    for (let name of AVAILABLE_OPTIONS) {
-      if (name !== 'fileUrl') {
-        let arg = name.replace(/[A-Z]/g, char => '-' + char.toLowerCase())
-        opts[name] = argv[arg] || process.env[ENVS[name]] || defaults[name]
-      }
-    }
-
-    opts.port = parseInt(opts.port, 10)
-    return opts
+    return loadOptions(
+      cliOptionsSpec,
+      process,
+      defaults.root ? { path: join(defaults.root, '.env') } : undefined,
+      defaults
+    )
   }
 
-  constructor (opts) {
-    if (!opts) opts = {}
+  constructor (opts = {}) {
     if (!opts.logger) {
       opts.logger = 'human'
     }
+
     let reporter = createReporter(opts)
 
     let initialized = false
@@ -166,20 +92,6 @@ export class Server extends BaseServer {
         process.exit(1)
       }
     })
-
-    for (let name in opts) {
-      if (!AVAILABLE_OPTIONS.includes(name)) {
-        let error = new Error(
-          `Unknown option \`${name}\` in server constructor`
-        )
-        error.logux = true
-        error.note =
-          'Maybe there is a mistake in option name or this ' +
-          'version of Logux Server doesn’t support this option'
-        error.option = name
-        throw error
-      }
-    }
 
     initialized = true
 

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -209,7 +209,7 @@ it('uses environment variables for config', () => {
   })
 })
 
-it('uses logger param', () => checkOut('options.js', ['', '--l', 'json']))
+it('uses logger param', () => checkOut('options.js', ['', '-l', 'json']))
 
 it('uses autoload modules', () => checkOut('autoload-modules.js'))
 
@@ -254,7 +254,7 @@ it('disables colors for constructor errors', () => {
 })
 
 it('uses logger param for constructor errors', () => {
-  return checkError('missed.js', ['', '--l', 'json'])
+  return checkError('missed.js', ['', '-l', 'json'])
 })
 
 it('writes to pino log', () => checkOut('pino.js'))


### PR DESCRIPTION
Aims:
 * Drop yargs
 * Add colors to simplify help perception
 * Unify handling of CLI, ENV, and JS arguments

Colored help looks like this:
![Screenshot from 2021-02-22 10-54-26](https://user-images.githubusercontent.com/15820496/108690024-e52d3500-750a-11eb-899d-0e6306ef098e.png)

Improvements:
* Commands like `node ./test/servers/options.js --por 4545` (wrong argument spelling) and `node ./test/servers/options.js --port 4535l` (wrong type of value) are not allowed now. With yargs they are just ignored, and the server starts with defaults

Decisions:
* We have 3 API. CLI and ENV require parsing and validation, JS requires only validation. Hence, validation is separated from parsing.
* All arguments that could be passed via CLI could be passed via ENV. This coupling seems adequate and simplifies configuration.
* To avoid triplication of API arguments, they are specified in one place.
* Arg parser and validation is project independent

Questions:
* Why `fileUrl` has special treatment in `loadOptions`
* Why we check that no unknown options are given after server construction? Can we do this check before?


If the overall design looks reasonable, I will, of course, add tests and cleanup code.