### PR TITLE
Preserve subscription context { data, headers, params } for channel unsubscribe callback

### DIFF
--- a/base-server/index.d.ts
+++ b/base-server/index.d.ts
@@ -720,7 +720,7 @@ export class BaseServer<
     [channel: string]: {
       [nodeId: string]: {
         filter: ChannelFilter<{}> | true
-        unsubscribe?: ChannelUnsubscribe<any, any, any>
+        unsubscribe?: (action: LoguxUnsubscribeAction, meta: ServerMeta) => void
       }
     }
   }

--- a/base-server/index.js
+++ b/base-server/index.js
@@ -748,7 +748,8 @@ export class BaseServer {
           this.subscribers[action.channel][ctx.nodeId] = {
             filter,
             unsubscribe: channel.unsubscribe
-              ? this.bindToSubscriptionContext(channel.unsubscribe, ctx)
+              ? (unsubscribeAction, unsubscribeMeta) =>
+                  channel.unsubscribe(ctx, unsubscribeAction, unsubscribeMeta)
               : undefined
           }
           subscribed = true
@@ -785,17 +786,6 @@ export class BaseServer {
     }
 
     if (!match) this.wrongChannel(action, meta)
-  }
-
-  bindToSubscriptionContext(channelUnsubscribe, subscriptionContext) {
-    let { data, headers, params } = subscriptionContext
-    return (action, meta) => {
-      let ctx = this.createContext(action, meta)
-      ctx.data = data
-      ctx.headers = headers
-      ctx.params = params
-      return channelUnsubscribe(ctx, action, meta)
-    }
   }
 
   performUnsubscribe(clientNodeId, action, meta) {

--- a/base-server/index.test.ts
+++ b/base-server/index.test.ts
@@ -1177,7 +1177,7 @@ it('calls unsubscribe() channel callback with logux/unsubscribe', async () => {
   let client: any = {
     node: {
       remoteSubprotocol: '0.0.0',
-      remoteHeaders: { preservedSubscribedClientHeaders: true },
+      remoteHeaders: { preservedClientHeaders: true },
       onAdd: () => false
     }
   }
@@ -1190,13 +1190,16 @@ it('calls unsubscribe() channel callback with logux/unsubscribe', async () => {
     meta.reasons.push('test')
   })
   let unsubscribeCallback = jest.fn()
-  test.app.channel<{ id: string }>('user/:id', {
-    access(ctx) {
-      ;(ctx.data as any).preservedInitialData = true
-      return true
-    },
-    unsubscribe: unsubscribeCallback
-  })
+  test.app.channel<{ id: string }, { preservedInitialData?: boolean }>(
+    'user/:id',
+    {
+      access(ctx) {
+        ctx.data.preservedInitialData = true
+        return true
+      },
+      unsubscribe: unsubscribeCallback
+    }
+  )
 
   await test.app.log.add(
     { type: 'logux/subscribe', channel: 'user/10' },
@@ -1223,7 +1226,7 @@ it('calls unsubscribe() channel callback with logux/unsubscribe', async () => {
       userId,
       clientId,
       data: { preservedInitialData: true },
-      headers: { preservedSubscribedClientHeaders: true },
+      headers: { preservedClientHeaders: true },
       params: { id: '10' },
       subprotocol: '0.0.0'
     }),

--- a/base-server/index.test.ts
+++ b/base-server/index.test.ts
@@ -1182,8 +1182,10 @@ it('calls unsubscribe() channel callback with logux/unsubscribe', async () => {
     }
   }
   let nodeId = '10:uuid'
+  let clientId = '10:uuid'
+  let userId = '10'
   test.app.nodeIds.set(nodeId, client)
-  test.app.clientIds.set('10:uuid', client)
+  test.app.clientIds.set(clientId, client)
   test.app.on('preadd', (action, meta) => {
     meta.reasons.push('test')
   })
@@ -1218,6 +1220,8 @@ it('calls unsubscribe() channel callback with logux/unsubscribe', async () => {
   expect(unsubscribeCallback).toHaveBeenCalledWith(
     expect.objectContaining({
       nodeId,
+      userId,
+      clientId,
       data: { preservedInitialData: true },
       headers: { preservedSubscribedClientHeaders: true },
       params: { id: '10' },


### PR DESCRIPTION
FYI the reason of failing build (.aValue typecheck failure) is present in current `next` branch