### PR TITLE
Allow any character save for `/` in channel name

### DIFF
--- a/base-server/index.js
+++ b/base-server/index.js
@@ -475,7 +475,7 @@ export class BaseServer {
     let channel = Object.assign({}, callbacks)
     if (typeof pattern === 'string') {
       channel.pattern = new UrlPattern(pattern, {
-        segmentValueCharset: 'a-zA-Z0-9-_~ %:'
+        segmentValueCharset: '^/'
       })
     } else {
       channel.regexp = pattern


### PR DESCRIPTION
Initial request - allow base64 encoded names. `=` was prohibited. We don't seem to use names in any context where a name should be restricted to some symbols