### PR TITLE
Fix processing of server actions when `accessAndProcess` callback is registered

### DIFF
--- a/base-server/index.js
+++ b/base-server/index.js
@@ -13,6 +13,7 @@ import { createHttpServer } from '../create-http-server/index.js'
 import { ServerClient } from '../server-client/index.js'
 import { Context } from '../context/index.js'
 
+const SKIP_PROCESS = Symbol('skipProcess')
 const RESEND_META = ['channels', 'users', 'clients', 'nodes']
 
 function optionError(msg) {
@@ -54,10 +55,14 @@ export class LoguxNotFoundError extends Error {
 
 function normalizeTypeCallbacks(name, callbacks) {
   if (callbacks && callbacks.accessAndProcess) {
-    callbacks.access = (...args) => {
+    callbacks.access = (ctx, ...args) => {
       return wasNot403(async () => {
-        await callbacks.accessAndProcess(...args)
+        await callbacks.accessAndProcess(ctx, ...args)
+        ctx[SKIP_PROCESS] = true
       })
+    }
+    callbacks.process = async (ctx, ...args) => {
+      if (!ctx[SKIP_PROCESS]) await callbacks.accessAndProcess(ctx, ...args)
     }
   }
   if (!callbacks || !callbacks.access) {

--- a/base-server/index.test.ts
+++ b/base-server/index.test.ts
@@ -83,7 +83,7 @@ async function catchError(cb: () => Promise<any>): Promise<Error> {
   } catch (e) {
     return e
   }
-  throw new Error('Error was not thown')
+  throw new Error('Error was not thrown')
 }
 
 afterEach(async () => {
@@ -1422,4 +1422,14 @@ it('subscribes clients manually', async () => {
   app.subscribe('test:1:1', 'users/10')
   await delay(10)
   expect(actions).toEqual([{ type: 'logux/subscribed', channel: 'users/10' }])
+})
+
+it('processes action with accessAndProcess callback', () => {
+  let test = createReporter()
+  let accessAndProcess = jest.fn(() => {})
+  test.app.type('A', {
+    accessAndProcess
+  })
+  test.app.process({ type: 'A' })
+  expect(accessAndProcess).toHaveBeenCalledTimes(1)
 })

--- a/server-client/index.test.ts
+++ b/server-client/index.test.ts
@@ -1769,6 +1769,49 @@ it('has shortcut to access and process in one callback', async () => {
   ])
 })
 
+it('process action exactly once with accessAndProcess callback', async () => {
+  let app = createServer()
+  app.log.keepActions()
+
+  app.type('FOO', {
+    async accessAndProcess(ctx) {
+      await ctx.sendBack({ type: 'REFOO' })
+    }
+  })
+  app.otherType({
+    async accessAndProcess(ctx, action) {
+      if (action.type === 'BAR') {
+        await ctx.sendBack({ type: 'REBAR' })
+      }
+    }
+  })
+
+  let client = await connectClient(app, '10:1:uuid')
+  await sendTo(client, [
+    'sync',
+    1,
+    { type: 'FOO' },
+    { id: [1, '10:1:uuid', 0], time: 1 }
+  ])
+  await delay(100)
+  await sendTo(client, [
+    'sync',
+    2,
+    { type: 'BAR' },
+    { id: [2, '10:1:uuid', 0], time: 1 }
+  ])
+  await delay(100)
+
+  expect(app.log.actions()).toEqual([
+    { type: 'FOO' },
+    { type: 'BAR' },
+    { type: 'REFOO' },
+    { type: 'logux/processed', id: '1 10:1:uuid 0' },
+    { type: 'REBAR' },
+    { type: 'logux/processed', id: '2 10:1:uuid 0' }
+  ])
+})
+
 it('denies access on 403 error', async () => {
   let app = createServer()
   app.log.keepActions()

--- a/test-client/index.test.ts
+++ b/test-client/index.test.ts
@@ -155,7 +155,7 @@ it('tracks action processing', async () => {
   )
 })
 
-it('detects action ID dublicate', async () => {
+it('detects action ID duplicate', async () => {
   server = new TestServer()
   server.type('FOO', {
     access: () => true


### PR DESCRIPTION
Thought about adding flag directly to `normalizeTypeCallbacks`, like
```
if (callbacks && callbacks.accessAndProcess) {
  callbacks.access = (...args) => {
    callbacks.skipProcess = true
    return wasNot403(async () => {
      await callbacks.accessAndProcess(...args)
    })
  }
  callbacks.process = async (...args) => {
    if (callbacks.skipProcess) {
      callbacks.skipProcess = false
      return
    }
    await callbacks.accessAndProcess(...args)
  }
}
```
But this state should be in the action not in the listener. e.g. some asynchronous magic and two actions call their access methods -> only one processed will be stopped.

Then I tried to set status: 'processed' but this messed up the whole action processing.

Thus, I decided to put the flag to action meta via Symbol not to conflict with user props.

But @ai said that it could ruin for example meta serialization to database, and we have context that is created per action, so it could be used.