### PR TITLE
addSyncMapFilter/initial: pass correct since value

### DIFF
--- a/add-sync-map/index.js
+++ b/add-sync-map/index.js
@@ -185,14 +185,14 @@ export function addSyncMapFilter(server, plural, operations) {
       }
     },
     async load(ctx, action, meta) {
+      let since = action.since ? action.since.time : 0
       let data = await operations.initial(
         ctx,
         action.filter,
-        action.since,
+        since,
         action,
         meta
       )
-      let since = action.since ? action.since.time : 0
       await Promise.all(
         data.map(async i => {
           await server.subscribe(ctx.nodeId, `${plural}/${i.id}`)


### PR DESCRIPTION
according to the typings, initial() should receive
`since` with type `number | undefined` as it's 3rd
parameter, but it actually receives a value of the
`action.since` which type is
`{ id: ID, time: number } | undefined`.