### PR TITLE
addSyncMap/load: fix types

### DIFF
--- a/add-sync-map/index.d.ts
+++ b/add-sync-map/index.d.ts
@@ -81,7 +81,7 @@ interface SyncMapOperations<Value extends SyncMapValues> {
     since: number | undefined,
     action: LoguxSubscribeAction,
     meta: ServerMeta
-  ): Promise<SyncMapData<Value>> | SyncMapData<Value> | false | Promise<false>
+  ): Promise<SyncMapData<Value> | false> | SyncMapData<Value> | false 
 
   create?(
     ctx: Context,


### PR DESCRIPTION
```
Type '(_: Context<{}, {}>, id: string, since: number | undefined) => Promise<false | SyncMapData<Value>>' is not assignable to type '(ctx: Context<{}, {}>, id: string, since: number | undefined, action: LoguxSubscribeAction, meta: ServerMeta) => false | Promise<false> | SyncMapData<...> | Promise<...>'.
  Type 'Promise<false | SyncMapData<Value>>' is not assignable to type 'false | Promise<false> | SyncMapData<Value> | Promise<SyncMapData<Value>>'.
    Type 'Promise<false | SyncMapData<Value>>' is not assignable to type 'Promise<false>'.
      Type 'false | SyncMapData<Value>' is not assignable to type 'false'.
        Type 'SyncMapData<Value>' is not assignable to type 'false'.
```