### PR TITLE
Multiple subscriptions with filters per node

### DIFF
--- a/base-server/index.d.ts
+++ b/base-server/index.d.ts
@@ -720,7 +720,7 @@ export class BaseServer<
   subscribers: {
     [channel: string]: {
       [nodeId: string]: {
-        filters: (ChannelFilter<{}> | true)[]
+        filters: Record<string, ChannelFilter<{}> | true>
         unsubscribe?: (action: LoguxUnsubscribeAction, meta: ServerMeta) => void
       }
     }

--- a/base-server/index.d.ts
+++ b/base-server/index.d.ts
@@ -720,7 +720,7 @@ export class BaseServer<
   subscribers: {
     [channel: string]: {
       [nodeId: string]: {
-        filter: ChannelFilter<{}> | true
+        filters: (ChannelFilter<{}> | true)[]
         unsubscribe?: (action: LoguxUnsubscribeAction, meta: ServerMeta) => void
       }
     }

--- a/base-server/index.js
+++ b/base-server/index.js
@@ -552,7 +552,7 @@ export class BaseServer {
       if (!this.subscribers[channel]) {
         this.subscribers[channel] = {}
       }
-      this.subscribers[channel][nodeId] = { filters: [true] }
+      this.subscribers[channel][nodeId] = { filters: { '{}': true } }
       this.log.add({ type: 'logux/subscribed', channel }, { nodes: [nodeId] })
     }
   }

--- a/base-server/index.js
+++ b/base-server/index.js
@@ -606,7 +606,7 @@ export class BaseServer {
               if (subscriber) {
                 let ctx = this.createContext(action, meta)
                 let client = this.clientIds.get(clientId)
-                for (let [, filter] of Object.entries(subscriber.filters)) {
+                for (let filter of Object.values(subscriber.filters)) {
                   filter = typeof filter === 'function'
                     ? await filter(ctx, action, meta)
                     : filter

--- a/base-server/index.js
+++ b/base-server/index.js
@@ -607,17 +607,15 @@ export class BaseServer {
               let subscriber = this.subscribers[channel][nodeId]
               if (subscriber) {
                 let ctx = this.createContext(action, meta)
-                let filters = subscriber.filters
+                let client = this.clientIds.get(clientId)
                 for (let filter of subscriber.filters) {
-                  filters = typeof filter === 'function'
+                  filter = typeof filter === 'function'
                     ? await filter(ctx, action, meta)
                     : filter
-                  if (!filters) break
-                }
-                let client = this.clientIds.get(clientId)
-                if (filters && client) {
-                  ignoreClients.add(clientId)
-                  client.node.onAdd(action, meta)
+                  if (filter && client) {
+                    ignoreClients.add(clientId)
+                    client.node.onAdd(action, meta)
+                  }
                 }
               }
             }

--- a/base-server/index.test.ts
+++ b/base-server/index.test.ts
@@ -1484,7 +1484,7 @@ it('subscribes clients manually', async () => {
   await delay(10)
   expect(app.subscribers).toEqual({
     'users/10': {
-      'test:1:1': { filters: [true] }
+      'test:1:1': { filters: { '{}': true } }
     }
   })
   expect(actions).toEqual([{ type: 'logux/subscribed', channel: 'users/10' }])

--- a/base-server/index.test.ts
+++ b/base-server/index.test.ts
@@ -1015,7 +1015,7 @@ it('subscribes clients', async () => {
   expect(test.reports[2][1].meta.status).toEqual('processed')
   expect(test.app.subscribers).toEqual({
     'user/10': {
-      '10:a:uuid': { filters: [true] }
+      '10:a:uuid': { filters: { '{}': true } }
     }
   })
   await test.app.log.add(
@@ -1027,10 +1027,10 @@ it('subscribes clients', async () => {
   expect(events).toEqual(2)
   expect(test.app.subscribers).toEqual({
     'user/10': {
-      '10:a:uuid': { filters: [true] }
+      '10:a:uuid': { filters: { '{}': true } }
     },
     'posts': {
-      '10:a:uuid': { filters: [filter] }
+      '10:a:uuid': { filters: { '{}': filter } }
     }
   })
   await test.app.log.add(
@@ -1059,7 +1059,68 @@ it('subscribes clients', async () => {
   })
   expect(test.app.subscribers).toEqual({
     posts: {
-      '10:a:uuid': { filters: [filter] }
+      '10:a:uuid': { filters: { '{}': filter } }
+    }
+  })
+})
+
+it('subscribes clients with multiple filters', async () => {
+  let test = createReporter()
+  let client: any = {
+    node: { remoteSubprotocol: '0.0.0', onAdd: () => false }
+  }
+  test.app.nodeIds.set('10:a:uuid', client)
+  test.app.clientIds.set('10:a', client)
+
+  let filter = (): boolean => false
+  test.app.channel('posts', {
+    access() {
+      return true
+    },
+    async filter() {
+      return filter
+    }
+  })
+
+  await test.app.log.add(
+    { type: 'logux/subscribe', channel: 'posts' },
+    { id: '1 10:a:uuid 0' }
+  )
+  await test.app.log.add(
+    { type: 'logux/subscribe', channel: 'posts', filter: { category: 'a' } },
+    { id: '1 10:a:uuid 0' }
+  )
+  await test.app.log.add(
+    { type: 'logux/subscribe', channel: 'posts', filter: { category: 'b' } },
+    { id: '1 10:a:uuid 0' }
+  )
+  await delay(1)
+  expect(test.app.subscribers).toEqual({
+    posts: {
+      '10:a:uuid': {
+        filters: {
+          '{}': filter,
+          '{"category":"a"}': filter,
+          '{"category":"b"}': filter
+        }
+      }
+    }
+  })
+
+  await test.app.log.add(
+    { type: 'logux/unsubscribe', channel: 'posts' },
+    { id: '2 10:a:uuid 0' }
+  )
+  await test.app.log.add(
+    { type: 'logux/unsubscribe', channel: 'posts', filter: { category: 'b' } },
+    { id: '2 10:a:uuid 0' }
+  )
+  await delay(1)
+  expect(test.app.subscribers).toEqual({
+    posts: {
+      '10:a:uuid': {
+        filters: { '{"category":"a"}': filter }
+      }
     }
   })
 })
@@ -1175,7 +1236,7 @@ it('loads initial actions during subscription', async () => {
   expect(userLoaded).toEqual(1)
   expect(test.app.subscribers).toEqual({
     'user/10': {
-      '10:uuid': { filters: [true] }
+      '10:uuid': { filters: { '{}': true } }
     }
   })
   expect(test.app.log.actions()).toEqual([

--- a/base-server/index.test.ts
+++ b/base-server/index.test.ts
@@ -1015,7 +1015,7 @@ it('subscribes clients', async () => {
   expect(test.reports[2][1].meta.status).toEqual('processed')
   expect(test.app.subscribers).toEqual({
     'user/10': {
-      '10:a:uuid': { filter: true }
+      '10:a:uuid': { filters: [true] }
     }
   })
   await test.app.log.add(
@@ -1027,10 +1027,10 @@ it('subscribes clients', async () => {
   expect(events).toEqual(2)
   expect(test.app.subscribers).toEqual({
     'user/10': {
-      '10:a:uuid': { filter: true }
+      '10:a:uuid': { filters: [true] }
     },
     'posts': {
-      '10:a:uuid': { filter }
+      '10:a:uuid': { filters: [filter] }
     }
   })
   await test.app.log.add(
@@ -1059,7 +1059,7 @@ it('subscribes clients', async () => {
   })
   expect(test.app.subscribers).toEqual({
     posts: {
-      '10:a:uuid': { filter }
+      '10:a:uuid': { filters: [filter] }
     }
   })
 })
@@ -1175,7 +1175,7 @@ it('loads initial actions during subscription', async () => {
   expect(userLoaded).toEqual(1)
   expect(test.app.subscribers).toEqual({
     'user/10': {
-      '10:uuid': { filter: true }
+      '10:uuid': { filters: [true] }
     }
   })
   expect(test.app.log.actions()).toEqual([
@@ -1423,7 +1423,7 @@ it('subscribes clients manually', async () => {
   await delay(10)
   expect(app.subscribers).toEqual({
     'users/10': {
-      'test:1:1': { filter: true }
+      'test:1:1': { filters: [true] }
     }
   })
   expect(actions).toEqual([{ type: 'logux/subscribed', channel: 'users/10' }])

--- a/server-client/index.test.ts
+++ b/server-client/index.test.ts
@@ -253,8 +253,8 @@ it('removes itself on destroy', async () => {
 
   test.app.subscribers = {
     'user/10': {
-      '10:client1': { filters: [true] },
-      '10:client2': { filters: [true] }
+      '10:client1': { filters: { '{}': true } },
+      '10:client2': { filters: { '{}': true } }
     }
   }
   client1.destroy()
@@ -262,7 +262,7 @@ it('removes itself on destroy', async () => {
 
   expect(Array.from(test.app.userIds.keys())).toEqual(['10'])
   expect(test.app.subscribers).toEqual({
-    'user/10': { '10:client2': { filters: [true] } }
+    'user/10': { '10:client2': { filters: { '{}': true } } }
   })
   expect(client1.connection.connected).toBe(false)
   expect(pullNewReports()).toMatchObject([
@@ -1080,17 +1080,17 @@ it('sends new actions by channel', async () => {
 
   let client = await connectClient(app)
   app.subscribers.foo = {
-    '10:uuid': { filters: [true] }
+    '10:uuid': { filters: { '{}': true } }
   }
   app.subscribers.bar = {
     '10:uuid': {
-      filters: [
-        (ctx, action, meta) => {
+      filters: {
+        '{}': (ctx, action, meta) => {
           expect(meta.id).toContain(' server:x ')
           expect(ctx.isServer).toBe(true)
           return privateMethods(action).secret !== true
         }
-      ]
+      }
     }
   }
   await app.log.add({ type: 'FOO' }, { id: '1 server:x 0' })
@@ -1130,8 +1130,8 @@ it('excludes client from channel', async () => {
   let client1 = await connectClient(app, '10:1:uuid')
   let client2 = await connectClient(app, '10:2:uuid')
   app.subscribers.foo = {
-    '10:1:uuid': { filters: [true] },
-    '10:2:uuid': { filters: [true] }
+    '10:1:uuid': { filters: { '{}': true } },
+    '10:2:uuid': { filters: { '{}': true } }
   }
   await app.log.add(
     { type: 'FOO' },
@@ -1156,8 +1156,8 @@ it('works with channel according client ID', async () => {
 
   let client = await connectClient(app, '10:uuid:a')
   app.subscribers.foo = {
-    '10:uuid:b': { filters: [true] },
-    '10:uuid:c': { filters: [true] }
+    '10:uuid:b': { filters: { '{}': true } },
+    '10:uuid:c': { filters: { '{}': true } }
   }
   await app.log.add({ type: 'FOO' }, { id: '2 server:x 0', channels: ['foo'] })
   sendTo(client, ['synced', 1])

--- a/server-client/index.test.ts
+++ b/server-client/index.test.ts
@@ -253,8 +253,8 @@ it('removes itself on destroy', async () => {
 
   test.app.subscribers = {
     'user/10': {
-      '10:client1': { filter: true },
-      '10:client2': { filter: true }
+      '10:client1': { filters: [true] },
+      '10:client2': { filters: [true] }
     }
   }
   client1.destroy()
@@ -262,7 +262,7 @@ it('removes itself on destroy', async () => {
 
   expect(Array.from(test.app.userIds.keys())).toEqual(['10'])
   expect(test.app.subscribers).toEqual({
-    'user/10': { '10:client2': { filter: true } }
+    'user/10': { '10:client2': { filters: [true] } }
   })
   expect(client1.connection.connected).toBe(false)
   expect(pullNewReports()).toMatchObject([
@@ -1080,15 +1080,17 @@ it('sends new actions by channel', async () => {
 
   let client = await connectClient(app)
   app.subscribers.foo = {
-    '10:uuid': { filter: true }
+    '10:uuid': { filters: [true] }
   }
   app.subscribers.bar = {
     '10:uuid': {
-      filter: (ctx, action, meta) => {
-        expect(meta.id).toContain(' server:x ')
-        expect(ctx.isServer).toBe(true)
-        return privateMethods(action).secret !== true
-      }
+      filters: [
+        (ctx, action, meta) => {
+          expect(meta.id).toContain(' server:x ')
+          expect(ctx.isServer).toBe(true)
+          return privateMethods(action).secret !== true
+        }
+      ]
     }
   }
   await app.log.add({ type: 'FOO' }, { id: '1 server:x 0' })
@@ -1128,8 +1130,8 @@ it('excludes client from channel', async () => {
   let client1 = await connectClient(app, '10:1:uuid')
   let client2 = await connectClient(app, '10:2:uuid')
   app.subscribers.foo = {
-    '10:1:uuid': { filter: true },
-    '10:2:uuid': { filter: true }
+    '10:1:uuid': { filters: [true] },
+    '10:2:uuid': { filters: [true] }
   }
   await app.log.add(
     { type: 'FOO' },
@@ -1154,8 +1156,8 @@ it('works with channel according client ID', async () => {
 
   let client = await connectClient(app, '10:uuid:a')
   app.subscribers.foo = {
-    '10:uuid:b': { filter: true },
-    '10:uuid:c': { filter: true }
+    '10:uuid:b': { filters: [true] },
+    '10:uuid:c': { filters: [true] }
   }
   await app.log.add({ type: 'FOO' }, { id: '2 server:x 0', channels: ['foo'] })
   sendTo(client, ['synced', 1])

--- a/test-client/index.test.ts
+++ b/test-client/index.test.ts
@@ -219,6 +219,17 @@ it('tracks subscriptions', async () => {
   expect(actions3).toEqual([{ type: 'FOO', since: { id: '1 1:0:0', time: 1 } }])
 
   await client.unsubscribe('foo', { a: 1 })
+  expect(privateMethods(server).subscribers).toEqual({
+    foo: {
+      '10:1:1': {
+        filters: {
+          '{}': true
+        }
+      }
+    }
+  })
+
+  await client.unsubscribe('foo')
   expect(privateMethods(server).subscribers).toEqual({})
 
   let actions4 = await client.subscribe({


### PR DESCRIPTION
Looks like we had a bug. When client is subscribed to the same channel multiple times, but with different filters, he no longer receives resent finished actions.

With this code, the client will only receive `posts/deleted` actions:
```js
let postsA = useFilter(PostsStore, { category: 'A' })
let postsB = useFilter(PostsStore, { category: 'B' })
```

With this PR we can subscribe on the same channel multiple times with different filters.
I used hashmap to collect filters so that it was easier to remove them on unsubscribe.