### PR TITLE
add 'unauthenticated' event, fix 'unsubscribed' event capabilities, update missing typedefs

### DIFF
--- a/base-server/index.d.ts
+++ b/base-server/index.d.ts
@@ -976,7 +976,7 @@ export class BaseServer<
    * @param listener Client listener.
    */
   on(
-    event: 'authenticated',
+    event: 'authenticated' | 'unauthenticated',
     listener: (client: ServerClient, latencyMilliseconds: number) => void
   ): Unsubscribe
 

--- a/base-server/index.d.ts
+++ b/base-server/index.d.ts
@@ -1010,8 +1010,9 @@ export class BaseServer<
     event: 'unsubscribed',
     listener: (
       action: LoguxUnsubscribeAction,
-      meta: Readonly<ServerMeta>
-    ) => void
+      meta: Readonly<ServerMeta>,
+      clientNodeId: string,
+    ) => void,
   ): Unsubscribe
 
   /**

--- a/base-server/index.d.ts
+++ b/base-server/index.d.ts
@@ -505,6 +505,7 @@ interface AuthenticationReporter {
 
 interface ReportersArguments {
   add: ActionReporter
+  addClean: ActionReporter
   authenticated: AuthenticationReporter
   clean: CleanReporter
   clientError: {

--- a/base-server/index.js
+++ b/base-server/index.js
@@ -657,7 +657,7 @@ export class BaseServer {
         }
       }
     }
-    this.emitter.emit('unsubscribed', action, meta)
+    this.emitter.emit('unsubscribed', action, meta, clientNodeId)
     this.emitter.emit('report', 'unsubscribed', {
       actionId: meta.id,
       channel: action.channel

--- a/server-client/index.js
+++ b/server-client/index.js
@@ -164,9 +164,6 @@ export class ServerClient {
       }
     }
     if (this.clientId) {
-      this.app.clientIds.delete(this.clientId)
-      this.app.nodeIds.delete(this.nodeId)
-
       for (let channel in this.app.subscribers) {
         let subscriber = this.app.subscribers[channel][this.nodeId]
         if (subscriber) {
@@ -176,6 +173,8 @@ export class ServerClient {
           this.app.performUnsubscribe(this.nodeId, action, meta)
         }
       }
+      this.app.clientIds.delete(this.clientId)
+      this.app.nodeIds.delete(this.nodeId)
     }
     if (!this.app.destroying) {
       this.app.emitter.emit('disconnected', this)

--- a/server-client/index.js
+++ b/server-client/index.js
@@ -77,6 +77,7 @@ export class ServerClient {
     }
 
     if (nodeId === 'server' || userId === 'server') {
+      this.app.emitter.emit('unauthenticated', this, 0)
       this.app.emitter.emit('report', 'unauthenticated', reportDetails(this))
       return false
     }
@@ -133,6 +134,7 @@ export class ServerClient {
       this.app.emitter.emit('authenticated', this, Date.now() - start)
       this.app.emitter.emit('report', 'authenticated', reportDetails(this))
     } else {
+      this.app.emitter.emit('unauthenticated', this, Date.now() - start)
       this.app.emitter.emit('report', 'unauthenticated', reportDetails(this))
       this.app.rememberBadAuth(this.remoteAddress)
     }

--- a/server-client/index.test.ts
+++ b/server-client/index.test.ts
@@ -257,9 +257,15 @@ it('removes itself on destroy', async () => {
       '10:client2': { filters: { '{}': true } }
     }
   }
+  let unsubscribedClientNodeIds: string[] = []
+  test.app.on('unsubscribed', (action, meta, clientNodeId) => {
+      unsubscribedClientNodeIds.push(clientNodeId)
+      expect(test.app.nodeIds.get(clientNodeId)).toBeDefined()
+  })
   client1.destroy()
   await delay(1)
 
+  expect(unsubscribedClientNodeIds).toEqual(['10:client1'])
   expect(Array.from(test.app.userIds.keys())).toEqual(['10'])
   expect(test.app.subscribers).toEqual({
     'user/10': { '10:client2': { filters: { '{}': true } } }
@@ -272,6 +278,8 @@ it('removes itself on destroy', async () => {
 
   client2.destroy()
   await delay(1)
+
+  expect(unsubscribedClientNodeIds).toEqual(['10:client1', '10:client2'])
   expect(pullNewReports()).toMatchObject([
     ['unsubscribed', { channel: 'user/10' }],
     ['disconnect', { nodeId: '10:client2' }]

--- a/server-client/index.test.ts
+++ b/server-client/index.test.ts
@@ -259,8 +259,8 @@ it('removes itself on destroy', async () => {
   }
   let unsubscribedClientNodeIds: string[] = []
   test.app.on('unsubscribed', (action, meta, clientNodeId) => {
-      unsubscribedClientNodeIds.push(clientNodeId)
-      expect(test.app.nodeIds.get(clientNodeId)).toBeDefined()
+    unsubscribedClientNodeIds.push(clientNodeId)
+    expect(test.app.nodeIds.get(clientNodeId)).toBeDefined()
   })
   client1.destroy()
   await delay(1)


### PR DESCRIPTION
Found that addClean reporter typedef is missing. Fixed.

Also while implementing suitable logging in my app I found out there are some bits missing:
- client unauthorized event (while unauthorized reporter exists with insufficient data) — added
- unsubscribe event does not have client nodeId server unsubscribes on ClientServer destroy — added without breaking changes