### PR TITLE
fix(add-sync-map-filter): action filter types and built-in filter

### DIFF
--- a/add-sync-map/index.d.ts
+++ b/add-sync-map/index.d.ts
@@ -1,8 +1,11 @@
 import type {
   LoguxSubscribeAction,
   SyncMapChangeAction,
+  SyncMapChangedAction,
   SyncMapCreateAction,
+  SyncMapCreatedAction,
   SyncMapDeleteAction,
+  SyncMapDeletedAction,
   SyncMapTypes,
   SyncMapValues
 } from '@logux/actions'
@@ -58,7 +61,10 @@ export function NoConflictResolution<
 interface SyncMapActionFilter<Value extends SyncMapValues> {
   (
     ctx: Context,
-    action: SyncMapCreateAction<Value> | SyncMapDeleteAction,
+    action:
+      | SyncMapChangedAction<Value>
+      | SyncMapCreatedAction<Value>
+      | SyncMapDeletedAction,
     meta: ServerMeta
   ): boolean | Promise<boolean>
 }
@@ -82,7 +88,7 @@ interface SyncMapOperations<Value extends SyncMapValues> {
     time: number,
     action: SyncMapChangeAction<Value>,
     meta: ServerMeta
-  ): boolean | Promise<boolean | void> | void 
+  ): boolean | Promise<boolean | void> | void
 
   create?(
     ctx: Context,

--- a/add-sync-map/index.js
+++ b/add-sync-map/index.js
@@ -44,6 +44,14 @@ function buildFilter(filter) {
         if (action.fields[key] !== filter[key]) return false
       }
     }
+    if (action.type.endsWith('/changed')) {
+      for (let key in filter) {
+        if (
+          action.fields[key] &&
+          action.fields[key] !== filter[key]
+        ) return false
+      }
+    }
     return true
   }
 }

--- a/add-sync-map/index.js
+++ b/add-sync-map/index.js
@@ -47,7 +47,7 @@ function buildFilter(filter) {
     if (action.type.endsWith('/changed')) {
       for (let key in filter) {
         if (
-          action.fields[key] &&
+          key in action.fields &&
           action.fields[key] !== filter[key]
         ) return false
       }


### PR DESCRIPTION
- Fixed types of resent actions
- Don’t resend `changed` actions that didn’t pass filter